### PR TITLE
Add license headers to 2 YAML files

### DIFF
--- a/.github/snippet-bot.yml
+++ b/.github/snippet-bot.yml
@@ -1,3 +1,17 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Presubmit test to check for mismatched region tags in PRs
 # https://github.com/googleapis/repo-automation-bots/tree/main/packages/snippet-bot
 # Install: https://github.com/apps/snippet-bot

--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -1,3 +1,17 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Synchronize repository settings from a centralized config
 # https://github.com/googleapis/repo-automation-bots/tree/main/packages/sync-repo-settings
 # Install: https://github.com/apps/sync-repo-settings


### PR DESCRIPTION
In [these Cloud Build Trigger logs](https://pantheon.corp.google.com/cloud-build/builds/019f8dd5-2407-4bc2-8bf3-d189c50759d9?project=cloud-foundation-cicd), we see:
```
Checking file headers
./.github/snippet-bot.yml
./.github/sync-repo-settings.yaml
```

This pull-request addresses the above issues.
