### PR TITLE
Add resource labels to GKE clusters

### DIFF
--- a/infra/main.tf
+++ b/infra/main.tf
@@ -52,6 +52,7 @@ resource "google_container_cluster" "my_cluster_usa" {
   location         = "us-west1"
   enable_autopilot = true
   project          = var.project_id
+  resource_labels  = var.labels
   depends_on = [
     module.enable_google_apis
   ]
@@ -78,6 +79,7 @@ resource "google_container_cluster" "my_cluster_europe" {
   location         = "europe-west1"
   enable_autopilot = true
   project          = var.project_id
+  resource_labels  = var.labels
   depends_on = [
     module.enable_google_apis
   ]
@@ -104,6 +106,7 @@ resource "google_container_cluster" "my_cluster_config" {
   location         = "us-west1"
   enable_autopilot = true
   project          = var.project_id
+  resource_labels  = var.labels
   depends_on = [
     module.enable_google_apis
   ]

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -14,13 +14,19 @@
  * limitations under the License.
  */
 
+variable "labels" {
+  type        = map(string)
+  default     = {}
+  description = "A set of key/value label pairs to assign to the resources deployed by this blueprint."
+}
+
 variable "project_id" {
   type        = string
-  description = "Google Cloud Project ID"
+  description = "The Google Cloud project ID."
 }
 
 variable "resource_name_suffix" {
   type        = string
   default     = "-1"
-  description = "Optional string added to the end of GCP resource names, allowing GCP project reuse"
+  description = "Optional string added to the end of resource names, allowing project reuse."
 }


### PR DESCRIPTION
This PR adds Google Cloud resource labels to the GKE clusters in TF.

Fixed #5 

Note that for GKE, the labels field is called `resource_labels` as per: https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_cluster

**Testing**
Apply the TF deployment using `-var 'labels={"mylabelkey"="mylabelvalue"}'`

You can see that the label shows up on the 3 GKE clusters:
![image](https://user-images.githubusercontent.com/3271352/232090449-24d78205-d560-474e-ab14-d80cd7eb6e3b.png)
