### PR TITLE
feat: Suffix static IP address with resource_name_suffix

### DIFF
--- a/infra/deploy_kubernetes_manifests.tf
+++ b/infra/deploy_kubernetes_manifests.tf
@@ -60,7 +60,7 @@ resource "kubernetes_job" "kubernetes_manifests_deployer_job" {
         service_account_name = local.k8s_service_account_name
         container {
           name  = "kubernetes-manifests-deployer"
-          image = "us-docker.pkg.dev/google-samples/containers/gke/kubernetes-manifests-deployer:v0.0.0.0"
+          image = "us-docker.pkg.dev/google-samples/containers/gke/kubernetes-manifests-deployer:v0.0.0.1"
           env {
             name  = "PROJECT_ID"
             value = var.project_id

--- a/infra/helm_chart_multi_cluster_ingress/templates/multi_cluster_ingress.yaml
+++ b/infra/helm_chart_multi_cluster_ingress/templates/multi_cluster_ingress.yaml
@@ -37,7 +37,7 @@ metadata:
   name: frontend-multi-cluster-ingress
   namespace: frontend
   annotations:
-    networking.gke.io/static-ip: https://www.googleapis.com/compute/v1/projects/{{ .Values.projectId }}/global/addresses/multi-cluster-ingress-ip-address
+    networking.gke.io/static-ip: https://www.googleapis.com/compute/v1/projects/{{ .Values.projectId }}/global/addresses/multi-cluster-ingress-ip-address{{ .Values.resourceNameSuffix }}
 spec:
   template:
     spec:

--- a/infra/multi_cluster_service.tf
+++ b/infra/multi_cluster_service.tf
@@ -25,7 +25,7 @@ resource "google_project_iam_member" "my_service_account_role_network_viewer" {
 
 resource "google_compute_global_address" "multi_cluster_ingress_ip_address" {
   provider     = google-beta
-  name         = "multi-cluster-ingress-ip-address"
+  name         = "multi-cluster-ingress-ip-address${var.resource_name_suffix}"
   address_type = "EXTERNAL"
   project      = var.project_id
   depends_on = [

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -28,5 +28,9 @@ variable "project_id" {
 variable "resource_name_suffix" {
   type        = string
   default     = "-1"
-  description = "Optional string added to the end of resource names, allowing project reuse."
+  description = <<EOT
+  Optional string added to the end of resource names, allowing project reuse.
+  This should be short and only contain dashes, lowercase letters, and digits.
+  It shoud not end with a dash.
+  EOT
 }

--- a/kubernetes_manifests_deployer/kubernetes_manifests/multi_cluster_ingress.yaml
+++ b/kubernetes_manifests_deployer/kubernetes_manifests/multi_cluster_ingress.yaml
@@ -48,7 +48,7 @@ metadata:
   annotations:
     meta.helm.sh/release-name: helm-chart-multi-cluster-ingress
     meta.helm.sh/release-namespace: frontend
-    networking.gke.io/static-ip: https://www.googleapis.com/compute/v1/projects/PROJECT_ID/global/addresses/multi-cluster-ingress-ip-address
+    networking.gke.io/static-ip: https://www.googleapis.com/compute/v1/projects/PROJECT_ID/global/addresses/multi-cluster-ingress-ip-addressRESOURCE_NAME_SUFFIX
 spec:
   template:
     spec:


### PR DESCRIPTION
### Background
* At the moment, the static IP address reserved for the `MultiClusterIngress` resources is named `multi-cluster-ingress-address`.

### The change
* We now suffix the name of the IP address with `resource_name_suffix`, so by default, the name of the IP address will be `multi-cluster-ingress-address-1`.
* This is necessary if we eventually fix https://github.com/GoogleCloudPlatform/terraform-ecommerce-microservices-on-gke/issues/2.

### Additional info
* Requirements regarding the name of the IP address ([source: Terraform resource docs](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_global_address#name)):

> The name must be 1-63 characters long, and comply with RFC1035. Specifically, the name must be 1-63 characters long and match the regular expression `[a-z]([-a-z0-9]*[a-z0-9])?` which means the first character must be a lowercase letter, and all following characters must be a dash, lowercase letter, or digit, except the last character, which cannot be a dash.

* After merging, we would have to update: https://github.com/GoogleCloudPlatform/terraform-ecommerce-microservices-on-gke/discussions/23.