### PR TITLE
fix: Un-hard-code token in Terraform K8s/Helm providers

### DIFF
--- a/infra/deploy_helm_charts.tf
+++ b/infra/deploy_helm_charts.tf
@@ -23,7 +23,6 @@ data "template_file" "helm_provider" {
   template = file("${path.module}/helm_provider.tf.template")
   vars = {
     cluster_host           = "https://${google_container_cluster.my_cluster_config.endpoint}"
-    cluster_token          = data.google_client_config.default.access_token
     cluster_ca_certificate = base64decode(google_container_cluster.my_cluster_config.master_auth[0].cluster_ca_certificate)
   }
   depends_on = [

--- a/infra/deploy_kubernetes_manifests.tf
+++ b/infra/deploy_kubernetes_manifests.tf
@@ -103,6 +103,9 @@ resource "kubernetes_service_account" "kubernetes_manifests_deployer_service_acc
       "iam.gke.io/gcp-service-account" = google_service_account.kubernetes_manifests_deployer_service_account.email
     }
   }
+  depends_on = [
+    google_container_cluster.my_cluster_config
+  ]
 }
 
 // The Google Cloud Service Account.

--- a/infra/deploy_kubernetes_manifests.tf
+++ b/infra/deploy_kubernetes_manifests.tf
@@ -29,7 +29,6 @@ data "template_file" "kubernetes_provider" {
   template = file("${path.module}/kubernetes_provider.tf.template")
   vars = {
     cluster_host           = "https://${google_container_cluster.my_cluster_config.endpoint}"
-    cluster_token          = data.google_client_config.default.access_token
     cluster_ca_certificate = base64decode(google_container_cluster.my_cluster_config.master_auth[0].cluster_ca_certificate)
   }
 }

--- a/infra/helm_provider.tf.template
+++ b/infra/helm_provider.tf.template
@@ -17,7 +17,7 @@
 provider "helm" {
   kubernetes {
     host                   = "${cluster_host}"
-    token                  = "${cluster_token}"
+    token                  = data.google_client_config.default.access_token
     cluster_ca_certificate = <<MyDelimiterWordForMultiLineString
 ${cluster_ca_certificate}
 MyDelimiterWordForMultiLineString

--- a/infra/kubernetes_provider.tf.template
+++ b/infra/kubernetes_provider.tf.template
@@ -16,7 +16,7 @@
 
 provider "kubernetes" {
   host                   = "${cluster_host}"
-  token                  = "${cluster_token}"
+  token                  = data.google_client_config.default.access_token
   cluster_ca_certificate = <<MyDelimiterWordForMultiLineString
 ${cluster_ca_certificate}
 MyDelimiterWordForMultiLineString

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -67,9 +67,6 @@ resource "google_container_cluster" "my_cluster_usa" {
   }
   node_config {
     service_account = google_service_account.my_service_account.email
-    oauth_scopes = [
-      "https://www.googleapis.com/auth/cloud-platform"
-    ]
   }
   provider = google-beta # Needed for the google_gkehub_feature Terraform module.
 }
@@ -94,9 +91,6 @@ resource "google_container_cluster" "my_cluster_europe" {
   }
   node_config {
     service_account = google_service_account.my_service_account.email
-    oauth_scopes = [
-      "https://www.googleapis.com/auth/cloud-platform"
-    ]
   }
   provider = google-beta # Needed for the google_gkehub_feature Terraform module.
 }
@@ -121,9 +115,6 @@ resource "google_container_cluster" "my_cluster_config" {
   }
   node_config {
     service_account = google_service_account.my_service_account.email
-    oauth_scopes = [
-      "https://www.googleapis.com/auth/cloud-platform"
-    ]
   }
   provider = google-beta # Needed for the google_gkehub_feature Terraform module.
 }


### PR DESCRIPTION
### Background
* When I implemented https://github.com/GoogleCloudPlatform/terraform-ecommerce-microservices-on-gke/commit/f70fb0310d8aeff105cbef33d5b3d0cc2c754b6e and https://github.com/GoogleCloudPlatform/terraform-ecommerce-microservices-on-gke/pull/20/commits/7de29aee2ed7d4f76b6772198d5566fccd8bdb2f, all three of the following variables were hard-coded:
    * `host`
    * `token`
    * `cluster_ca_certificate`
* However, as mentioned in [this comment](https://github.com/hashicorp/terraform-provider-kubernetes/issues/1028#issuecomment-1513526385), I didn't check if _all three_ had to be hard-coded.
* The token has an lifespan of 1 hour — so hard-coding the token is a problem.
    * This means that if `terraform destroy` is done more than an hour _after_ `terraform apply`, the `token` would have expired and `terraform destroy` would fail to destroy the Kubernetes ServiceAccount (encountered in [issue 26](https://github.com/GoogleCloudPlatform/terraform-ecommerce-microservices-on-gke/issues/26)).

### Solution
* It turns out that we do not need to hard-code the value of the `token` (`data.google_client_config.default.access_token`) — only the variables from `google_container_cluster` need to be hard-coded (confirming [this root cause analysis](https://github.com/hashicorp/terraform-provider-kubernetes/issues/1028#issuecomment-800934615)).
* Let's revert to using `data.google_client_config.default.access_token`.

### Additional Info
* This pull-request hopes to fix https://github.com/GoogleCloudPlatform/terraform-ecommerce-microservices-on-gke/issues/26.