### PR TITLE
fix: Separate MCI APIs from other Google Cloud APIs

### DIFF
--- a/infra/cluster_fleet_memberships.tf
+++ b/infra/cluster_fleet_memberships.tf
@@ -22,6 +22,9 @@ resource "google_gke_hub_membership" "my_fleet_membership_usa" {
       resource_link = "//container.googleapis.com/${google_container_cluster.my_cluster_usa.id}"
     }
   }
+  depends_on = [
+    module.enable_multi_cluster_google_apis
+  ]
   provider = google-beta
 }
 
@@ -33,6 +36,9 @@ resource "google_gke_hub_membership" "my_fleet_membership_europe" {
       resource_link = "//container.googleapis.com/${google_container_cluster.my_cluster_europe.id}"
     }
   }
+  depends_on = [
+    module.enable_multi_cluster_google_apis
+  ]
   provider = google-beta
 }
 
@@ -44,5 +50,8 @@ resource "google_gke_hub_membership" "my_fleet_membership_config" {
       resource_link = "//container.googleapis.com/${google_container_cluster.my_cluster_config.id}"
     }
   }
+  depends_on = [
+    module.enable_multi_cluster_google_apis
+  ]
   provider = google-beta
 }

--- a/infra/deploy_kubernetes_manifests.tf
+++ b/infra/deploy_kubernetes_manifests.tf
@@ -94,6 +94,7 @@ resource "kubernetes_job" "kubernetes_manifests_deployer_job" {
     google_project_iam_member.google_service_account_is_kubernetes_admin,
     google_service_account_iam_member.allow_kubernetes_sa_to_impersonate_google_cloud_sa,
     kubernetes_service_account.kubernetes_manifests_deployer_service_account,
+    module.enable_multi_cluster_google_apis,
   ]
 }
 
@@ -117,7 +118,7 @@ resource "google_service_account" "kubernetes_manifests_deployer_service_account
   account_id   = local.google_service_account_id
   display_name = "Kubernetes Manifests Deployer"
   depends_on = [
-    module.enable_google_apis
+    module.enable_base_google_apis
   ]
 }
 

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -22,16 +22,24 @@ provider "google-beta" {
   project = var.project_id
 }
 
-module "enable_google_apis" {
+module "enable_base_google_apis" {
   source                      = "terraform-google-modules/project-factory/google//modules/project_services"
   version                     = "~> 14.0"
   disable_services_on_destroy = false
   activate_apis = [
     "cloudresourcemanager.googleapis.com",
     "container.googleapis.com",
-    "dns.googleapis.com",
-    "gkehub.googleapis.com",
     "iam.googleapis.com",
+  ]
+  project_id = var.project_id
+}
+
+module "enable_multi_cluster_google_apis" {
+  source                      = "terraform-google-modules/project-factory/google//modules/project_services"
+  version                     = "~> 14.0"
+  disable_services_on_destroy = false
+  activate_apis = [
+    "gkehub.googleapis.com",
     "multiclusteringress.googleapis.com",
     "multiclusterservicediscovery.googleapis.com",
     "trafficdirector.googleapis.com",
@@ -43,7 +51,7 @@ resource "google_service_account" "my_service_account" {
   account_id   = "my-service-account${var.resource_name_suffix}"
   display_name = "My Service Account"
   depends_on = [
-    module.enable_google_apis
+    module.enable_base_google_apis
   ]
 }
 
@@ -54,7 +62,7 @@ resource "google_container_cluster" "my_cluster_usa" {
   project          = var.project_id
   resource_labels  = var.labels
   depends_on = [
-    module.enable_google_apis
+    module.enable_base_google_apis
   ]
   cluster_autoscaling {
     auto_provisioning_defaults {
@@ -78,7 +86,7 @@ resource "google_container_cluster" "my_cluster_europe" {
   project          = var.project_id
   resource_labels  = var.labels
   depends_on = [
-    module.enable_google_apis
+    module.enable_base_google_apis
   ]
   cluster_autoscaling {
     auto_provisioning_defaults {
@@ -102,7 +110,7 @@ resource "google_container_cluster" "my_cluster_config" {
   project          = var.project_id
   resource_labels  = var.labels
   depends_on = [
-    module.enable_google_apis
+    module.enable_base_google_apis
   ]
   cluster_autoscaling {
     auto_provisioning_defaults {

--- a/infra/multi_cluster_service.tf
+++ b/infra/multi_cluster_service.tf
@@ -19,7 +19,7 @@ resource "google_project_iam_member" "my_service_account_role_network_viewer" {
   role    = "roles/compute.networkViewer"
   member  = "serviceAccount:${google_service_account.my_service_account.email}"
   depends_on = [
-    module.enable_google_apis
+    module.enable_base_google_apis
   ]
 }
 
@@ -29,7 +29,7 @@ resource "google_compute_global_address" "multi_cluster_ingress_ip_address" {
   address_type = "EXTERNAL"
   project      = var.project_id
   depends_on = [
-    module.enable_google_apis
+    module.enable_base_google_apis
   ]
 }
 
@@ -43,6 +43,9 @@ resource "google_gke_hub_feature" "multi_cluster_ingress_feature" {
     }
   }
   provider = google-beta
+  depends_on = [
+    module.enable_multi_cluster_google_apis
+  ]
 }
 
 resource "google_project_iam_member" "gke_mcs_importer_iam_binding" {


### PR DESCRIPTION
* This fixes #19.

### Summary
* MCI = Multi Cluster Ingress
* This pull-request separates the enablement of MCI Google Cloud APIs from other APIs.
* This allows Terraform to provision non-MCI-related resources without waiting for MCI APIs.
* For instance, the Terraform to begin cluster creation before the MCI APIs are enabled.
* The is purely a performance enhancement.
* This pull-request also removes the `dns.googleapis.com`. Reason: The `dns.googleapis.com` API no longer needs manual enablement, since it's enabled by the all GKE-enabled projects ([source](https://services.google.com/fh/files/helpcenter/cloud_dns_for_gke_faq.pdf)).