### PR TITLE
fix: bring back example.DefaultVerify(assert)

### DIFF
--- a/infra/test/integration/simple_example/simple_example_test.go
+++ b/infra/test/integration/simple_example/simple_example_test.go
@@ -34,6 +34,7 @@ func TestSimpleExample(t *testing.T) {
 	example := tft.NewTFBlueprintTest(t)
 
 	example.DefineVerify(func(assert *assert.Assertions) {
+		example.DefaultVerify(assert)
 		projectId := example.GetTFSetupStringOutput("project_id")
 		deploymentIpAddr := example.GetStringOutput("deployment_ip_address")
 		deploymentUrl := fmt.Sprintf("http://%s", deploymentIpAddr)


### PR DESCRIPTION
* This is an attempt to bring back the `example.DefaultVerify(assert)` line that we removed in the last commit of [pull-request 14](https://github.com/GoogleCloudPlatform/terraform-ecommerce-microservices-on-gke/pull/14/commits).
* This `example.DefaultVerify(assert)` was removed because it fails. It fails because Google Cloud mutates resources deployed by the Terraform — after `terraform apply`.
* Since the Google Cloud mutation happens _after_ `terraform apply`, the Terraform state isn't aware of the change and complains about the delta. 
* Ideally, we identify this delta (i.e., the mutation that Google Cloud makes) and apply the mutation in the Terraform itself, to remove the delta.