### PR TITLE
fix: Remove my_service_account_role_network_viewer

### DIFF
--- a/infra/multi_cluster_service.tf
+++ b/infra/multi_cluster_service.tf
@@ -14,15 +14,6 @@
  * limitations under the License.
  */
 
-resource "google_project_iam_member" "my_service_account_role_network_viewer" {
-  project = var.project_id
-  role    = "roles/compute.networkViewer"
-  member  = "serviceAccount:${google_service_account.my_service_account.email}"
-  depends_on = [
-    module.enable_google_apis
-  ]
-}
-
 resource "google_compute_global_address" "multi_cluster_ingress_ip_address" {
   provider     = google-beta
   name         = "multi-cluster-ingress-ip-address${var.resource_name_suffix}"

--- a/infra/test/integration/simple_example/simple_example_test.go
+++ b/infra/test/integration/simple_example/simple_example_test.go
@@ -67,7 +67,7 @@ func testDeploymentUrl(t *testing.T, assert *assert.Assertions, url string) erro
 		}
 
 		// Wait before retrying.
-		time.Sleep(4 * time.Second)
+		time.Sleep(5 * time.Second)
 	}
 
 	t.Logf("Waited too long for deployment URL.\n")


### PR DESCRIPTION
### Background

This pull-request removes a `google_project_iam_member` resource.

Judging from [this comment](https://github.com/GoogleCloudPlatform/terraform-ecommerce-microservices-on-gke/pull/14/files#diff-baddbdbb911ba09697cbb6a8dcf458f81f1b72f2a44d135bf1f1ec48affcc4fe), I added this `google_project_iam_member` resource because of [this cloud.google.com documentation about multi-cluster services](https://cloud.google.com/kubernetes-engine/docs/how-to/multi-cluster-services#authenticating). But that cloud.google.com doc also says:
> You do not need to do any steps in this section if you registered a cluster to a fleet with Workload Identity enabled.

So maybe we actually don't need it (and I added it by mistake).

