### PR TITLE
fix: Add Monitoring & Logging roles to allow for metrics & logs to ingest

### DIFF
--- a/infra/main.tf
+++ b/infra/main.tf
@@ -57,6 +57,30 @@ resource "google_service_account" "my_service_account" {
   ]
 }
 
+resource "google_project_iam_member" "my_service_account_role_metric_writer" {
+  project = var.project_id
+  role    = "roles/monitoring.metricWriter"
+  member  = "serviceAccount:${google_service_account.my_service_account.email}"
+}
+
+resource "google_project_iam_member" "my_service_account_role_log_writer" {
+  project = var.project_id
+  role    = "roles/logging.logWriter"
+  member  = "serviceAccount:${google_service_account.my_service_account.email}"
+}
+
+resource "google_project_iam_member" "my_service_account_role_monitoring_viewer" {
+  project = var.project_id
+  role    = "roles/monitoring.viewer"
+  member  = "serviceAccount:${google_service_account.my_service_account.email}"
+}
+
+resource "google_project_iam_member" "my_service_account_role_stackdriver_writer" {
+  project = var.project_id
+  role    = "roles/stackdriver.resourceMetadata.writer"
+  member  = "serviceAccount:${google_service_account.my_service_account.email}"
+}
+
 resource "google_container_cluster" "my_cluster_usa" {
   name             = "my-cluster-usa${var.resource_name_suffix}"
   location         = "us-west1"

--- a/infra/multi_cluster_service.tf
+++ b/infra/multi_cluster_service.tf
@@ -23,6 +23,24 @@ resource "google_project_iam_member" "my_service_account_role_network_viewer" {
   ]
 }
 
+resource "google_project_iam_member" "my_service_account_role_metrics_writer" {
+  project = var.project_id
+  role    = "roles/monitoring.metricWriter"
+  member  = "serviceAccount:${google_service_account.my_service_account.email}"
+  depends_on = [
+    module.enable_base_google_apis
+  ]
+}
+
+resource "google_project_iam_member" "my_service_account_role_log_writer" {
+  project = var.project_id
+  role    = "roles/logging.logWriter"
+  member  = "serviceAccount:${google_service_account.my_service_account.email}"
+  depends_on = [
+    module.enable_base_google_apis
+  ]
+}
+
 resource "google_compute_global_address" "multi_cluster_ingress_ip_address" {
   provider     = google-beta
   name         = "multi-cluster-ingress-ip-address${var.resource_name_suffix}"

--- a/infra/multi_cluster_service.tf
+++ b/infra/multi_cluster_service.tf
@@ -23,24 +23,6 @@ resource "google_project_iam_member" "my_service_account_role_network_viewer" {
   ]
 }
 
-resource "google_project_iam_member" "my_service_account_role_metrics_writer" {
-  project = var.project_id
-  role    = "roles/monitoring.metricWriter"
-  member  = "serviceAccount:${google_service_account.my_service_account.email}"
-  depends_on = [
-    module.enable_base_google_apis
-  ]
-}
-
-resource "google_project_iam_member" "my_service_account_role_log_writer" {
-  project = var.project_id
-  role    = "roles/logging.logWriter"
-  member  = "serviceAccount:${google_service_account.my_service_account.email}"
-  depends_on = [
-    module.enable_base_google_apis
-  ]
-}
-
 resource "google_compute_global_address" "multi_cluster_ingress_ip_address" {
   provider     = google-beta
   name         = "multi-cluster-ingress-ip-address${var.resource_name_suffix}"


### PR DESCRIPTION
This fixes #61.
* The 4 roles we're adding are based on [this GKE documentation](https://cloud.google.com/kubernetes-engine/docs/how-to/hardening-your-cluster#use_least_privilege_sa).
