### PR TITLE
fix: Use Google TF providers >= v4.80.0

### DIFF
--- a/infra/versions.tf
+++ b/infra/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 3.25.0, <= 4.74, != 4.75.0"
+      version = ">= 4.80.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 3.25.0, <= 4.74, != 4.75.0"
+      version = ">= 4.80.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"


### PR DESCRIPTION
## Background
* In [b/301061877](http://b/301061877) (Google-internal bug), users got the following error when trying to destroy JSS 8.1:
```
Error: Get ... http://localhost/api/v1/namespaces/default/serviceaccounts/k8s-manifests-deployer-service-account\"": dial tcp 127.0.0.1:80: connect: connection refused
```
* In the error message, we see that `terraform destroy` thinks the URL of one of the GKE clusters is `http://localhost`. This means that the Kubernetes Terraform provider isn't using the cluster details from [/infra/kubernetes_provider.tf](https://github.com/GoogleCloudPlatform/terraform-ecommerce-microservices-on-gke/blob/v0.1.2/infra/kubernetes_provider.tf#L19).
* The reason this happens is explained in [this comment](https://github.com/hashicorp/terraform-provider-kubernetes/issues/1028#issuecomment-800934615): there is a significant difference/delta between the state defined in our Terraform files versus the actual state (of the cluster) that exists on Google Cloud — so significant that Terraform thinks the GKE cluster needs to be recreated and ignores the existing endpoint (and resorts to `localhost`).
* To find that "significant difference/delta", I temporarily added `example.DefaultVerify(assert)` inside our integration test, in [pull-request 86](https://github.com/GoogleCloudPlatform/terraform-ecommerce-microservices-on-gke/pull/86/files). More specifically, we can see the difference/delta in [these Cloud Build logs](https://console.cloud.google.com/cloud-build/builds/68b4d01d-76a5-46a3-bfaf-1782356715da;step=3?e=13803378&mods=notebooks_use_staging_api&project=cloud-foundation-cicd) of failing integration tests:
```
Running stage verify
...
# module.ecommerce_microservices_on_gke.google_container_cluster.my_cluster_config must be replaced
...
dns_config { # forces replacement
    cluster_dns        = "CLOUD_DNS" -> null
    cluster_dns_domain = "cluster.local" -> null
    cluster_dns_scope  = "CLUSTER_SCOPE" -> null
}
```
* Notice the `forces replacement` message in the logs because of a delta related to the `dns_config` value of the `my_cluster_config` GKE cluster. This sudden breakage was partially a result of [GKE adopting Cloud DNS](https://services.google.com/fh/files/helpcenter/cloud_dns_for_gke_faq.pdf).
* Typically, that `dns_config` delta should be fine and should NOT result in "forces replacement" (i.e., the cluster should NOT be recreated). But `terraform-provider-google` thinks the detla should force replacement/recreation of the GKE cluster.
* According to [this comment](https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/issues/1713#issuecomment-1708710732), this issue has been fixed in `terraform-provider-google` `v4.80.0`. See [release notes of `terraform-provider-google` `v4.80.0`](https://github.com/hashicorp/terraform-provider-google/releases/tag/v4.80.0#:~:text=ignore%20dns_config%20diff).

## Summary of change

* Force Terraform to use Google's Terraform provider `v4.80.0` or above.