### PR TITLE
fix: Build and update K8 deployer Docker image

### DIFF
--- a/infra/deploy_kubernetes_manifests.tf
+++ b/infra/deploy_kubernetes_manifests.tf
@@ -38,7 +38,7 @@ resource "kubernetes_job" "kubernetes_manifests_deployer_job" {
         service_account_name = local.k8s_service_account_name
         container {
           name  = "kubernetes-manifests-deployer"
-          image = "us-docker.pkg.dev/google-samples/containers/gke/kubernetes-manifests-deployer:v0.0.1-test1"
+          image = "us-docker.pkg.dev/google-samples/containers/gke/kubernetes-manifests-deployer:v0.0.0.3-test1"
           env {
             name  = "PROJECT_ID"
             value = var.project_id

--- a/infra/deploy_kubernetes_manifests.tf
+++ b/infra/deploy_kubernetes_manifests.tf
@@ -38,7 +38,7 @@ resource "kubernetes_job" "kubernetes_manifests_deployer_job" {
         service_account_name = local.k8s_service_account_name
         container {
           name  = "kubernetes-manifests-deployer"
-          image = "us-docker.pkg.dev/google-samples/containers/gke/kubernetes-manifests-deployer:v0.0.0.3-test1"
+          image = "us-docker.pkg.dev/google-samples/containers/gke/kubernetes-manifests-deployer:v0.0.0.3"
           env {
             name  = "PROJECT_ID"
             value = var.project_id

--- a/infra/deploy_kubernetes_manifests.tf
+++ b/infra/deploy_kubernetes_manifests.tf
@@ -38,7 +38,7 @@ resource "kubernetes_job" "kubernetes_manifests_deployer_job" {
         service_account_name = local.k8s_service_account_name
         container {
           name  = "kubernetes-manifests-deployer"
-          image = "us-docker.pkg.dev/google-samples/containers/gke/kubernetes-manifests-deployer:v0.0.0.2"
+          image = "us-docker.pkg.dev/google-samples/containers/gke/kubernetes-manifests-deployer:v0.0.1-test1"
           env {
             name  = "PROJECT_ID"
             value = var.project_id


### PR DESCRIPTION
Background
* This Jump Start Solution deploys 3 GKE clusters.
* Since we weren't (months ago) able to run `kubectl` using Terraform `local-execs` to deploy Kubernetes resources, we had to run `kubectl` commands inside one of the GKE clusters (using a [Kubernetes Job](https://github.com/GoogleCloudPlatform/terraform-ecommerce-microservices-on-gke/blob/v0.1.4/infra/deploy_kubernetes_manifests.tf#L27)).
* The Kubernetes Job deploys most of the Kubernetes resources on all 3 clusters.
* The Kubernetes Job uses the [image `us-docker.pkg.dev/google-samples/containers/gke/kubernetes-manifests-deployer:v0.0.0.2`](https://pantheon.corp.google.com/artifacts/docker/google-samples/us/containers/gke%2Fkubernetes-manifests-deployer), which was last updated on May 19, 2023.
* The source code for that image: [/kubernetes_manifests_deployer folder](https://github.com/GoogleCloudPlatform/terraform-ecommerce-microservices-on-gke/tree/main/kubernetes_manifests_deployer).

What is this change?
* I have built a new version of the image.
* Please also see Google-internal link: [b/356830715](http://b/356830715).

Additional info
* After merging this, I will need to update the `sic-jss` tag, so that the Cloud Console uses the latest version of this Terraform.
* This update removes +120 vulnerabilities:
![Screenshot 2024-08-01 at 2 46 26 PM](https://github.com/user-attachments/assets/684879ac-8ab0-46e4-90f4-6704cd0a0e41)

